### PR TITLE
Godot Script Parsing

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -12,6 +12,8 @@ var fetchCmd = &cobra.Command{
 	Long:  "Fetch all dependencies defined in your project",
 	Run: func(cmd *cobra.Command, args []string) {
 		myApp := getApp()
+
+		// Perform the fetch operation
 		if err := myApp.Fetch(); err != nil {
 			fmt.Println("Error:", err)
 		} else {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -2,12 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"gogetty/pkg/app"
 
 	"github.com/spf13/cobra"
 )
-
-var myApp *app.MyApp
 
 var removeCmd = &cobra.Command{
 	Use:   "remove <name>",
@@ -16,22 +13,15 @@ var removeCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
+		myApp := getApp()
 		if err := myApp.Remove(name); err != nil {
 			fmt.Println("Error:", err)
 		} else {
 			fmt.Printf("Dependency '%s' removed successfully\n", name)
 		}
 	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		moduleNames, err := myApp.ListModuleNames()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-		return moduleNames, cobra.ShellCompDirectiveNoFileComp
-	},
 }
 
 func init() {
-	myApp = getApp()
 	rootCmd.AddCommand(removeCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.8.0
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,6 @@ github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyh
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -18,7 +18,6 @@ type App interface {
 	Update(name, branch, commit string, directories []string) error
 	List() ([]project.Dependency, error)
 	Clean() error
-	ListModuleNames() ([]string, error)
 }
 
 type MyApp struct {
@@ -41,6 +40,7 @@ func (m *MyApp) Init() error {
 	}
 
 	cache.AddClient(m.ProjectDir)
+
 	return nil
 }
 
@@ -133,8 +133,17 @@ func (m *MyApp) Fetch() error {
 		}
 	}
 
+	proj, err := project.GetProjectFile("")
+
 	if len(proj.Dependencies) == 0 {
+		if err == nil {
+			gitop.RemoveIgnore(m.ProjectDir, proj.ModulesDir)
+		}
 		return nil
+	} else {
+		if err == nil {
+			gitop.Ignore(m.ProjectDir, proj.ModulesDir)
+		}
 	}
 
 	// Perform recursive fetch
@@ -236,14 +245,4 @@ func (m *MyApp) Clean() error {
 	}
 
 	return nil
-}
-
-func (m *MyApp) ListModuleNames() ([]string, error) {
-	var moduleNames []string
-	for _, repo := range m.Cache {
-		if repo.Name != "" {
-			moduleNames = append(moduleNames, repo.Name)
-		}
-	}
-	return moduleNames, nil
 }

--- a/pkg/app/util.go
+++ b/pkg/app/util.go
@@ -18,7 +18,6 @@ func fetchRecursive(projectDir string, modules []gitop.GitRepo) error {
 		} else {
 			return nil
 		}
-
 	}
 
 	proj, err := project.GetProjectFile(projectDir)
@@ -28,7 +27,6 @@ func fetchRecursive(projectDir string, modules []gitop.GitRepo) error {
 		} else {
 			return nil
 		}
-
 	}
 
 	var allErrors []error

--- a/pkg/gitop/fetch.go
+++ b/pkg/gitop/fetch.go
@@ -2,6 +2,7 @@ package gitop
 
 import (
 	"fmt"
+	"gogetty/pkg/godot"
 	"net/url"
 	"os/exec"
 	"path"
@@ -52,7 +53,15 @@ func Fetch(cacheDir, gitURL, branch, commit string) (*GitRepo, error) {
 		Name:   name,
 	}
 
-	fmt.Printf("repo fetched: %v\n", repo)
+	godotProject, err := godot.GetGodotProject(fullCacheDir)
+	if err != nil {
+		return &repo, nil
+	}
+
+	err = godot.UpdateProjectPaths(*godotProject)
+	if err != nil {
+		return &repo, nil
+	}
 
 	return &repo, nil
 }

--- a/pkg/godot/godot.go
+++ b/pkg/godot/godot.go
@@ -1,0 +1,111 @@
+package godot
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"gopkg.in/ini.v1"
+)
+
+type GodotScript struct {
+	LineCount int
+	Path      string
+	Type      string
+}
+
+type GodotProject struct {
+	Name                string
+	GodotVersion        string
+	Path                string
+	CustomUserDirectory bool
+	UserDirectory       string
+	Features            []string
+	Scripts             []GodotScript
+}
+
+func (gp *GodotProject) SetUserDirectory() {
+	if gp.CustomUserDirectory {
+		// Set custom directory path
+		if gp.UserDirectory != "" {
+			// Custom dir and name
+			gp.UserDirectory = getUserDirPath(gp.UserDirectory)
+		} else {
+			// Custom dir only
+			gp.UserDirectory = getUserDirPath(gp.Name)
+		}
+	} else {
+		// Set default directory path
+		gp.UserDirectory = getDefaultUserDirPath(gp.Name)
+	}
+}
+
+func getDefaultUserDirPath(projectName string) string {
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join("%APPDATA%", "Godot", "app_userdata", projectName)
+	case "darwin":
+		return filepath.Join("~/Library/Application Support/Godot/app_userdata", projectName)
+	default: // Linux and other OS
+		return filepath.Join("~/.local/share/godot/app_userdata", projectName)
+	}
+}
+
+func getUserDirPath(dirName string) string {
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join("%APPDATA%", dirName)
+	case "darwin":
+		return filepath.Join("~/Library/Application Support", dirName)
+	default: // Linux and other OS
+		return filepath.Join("~/.local/share", dirName)
+	}
+}
+
+func UpdateProjectPaths(project GodotProject) error {
+	for _, script := range project.Scripts {
+		err := parseScriptPaths(&script, project)
+		if err != nil {
+			fmt.Println("Godot Script failed to parse: ", filepath.Base(script.Path))
+		}
+	}
+	return nil
+}
+
+func GetGodotProject(dirPath string) (*GodotProject, error) {
+	projectFilePath := filepath.Join(dirPath, "project.godot")
+	cfg, err := ini.Load(projectFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var godotProject GodotProject
+
+	// Extract values with default handling
+	if name, err := cfg.Section("application").GetKey("config/name"); err == nil {
+		godotProject.Name = name.String()
+	}
+	if useCustomDir, err := cfg.Section("application").GetKey("config/use_custom_user_dir"); err == nil {
+		godotProject.CustomUserDirectory = useCustomDir.MustBool(false)
+	}
+	if customDirName, err := cfg.Section("application").GetKey("config/custom_user_dir_name"); err == nil {
+		godotProject.UserDirectory = customDirName.String()
+	} else if godotProject.CustomUserDirectory {
+		godotProject.UserDirectory = godotProject.Name
+	}
+
+	// Set user directory based on the parsed values
+	godotProject.SetUserDirectory()
+
+	// Walk the project directory to generate script lists
+	gdScripts, csScripts, err := walkProjectDirectory(dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Append the script lists to the GodotProject's Scripts field
+	godotProject.Scripts = append(godotProject.Scripts, gdScripts...)
+	godotProject.Scripts = append(godotProject.Scripts, csScripts...)
+
+	return &godotProject, nil
+}

--- a/pkg/godot/parser.go
+++ b/pkg/godot/parser.go
@@ -1,0 +1,81 @@
+package godot
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WalkProjectDirectory walks the entire project directory and generates script lists.
+func walkProjectDirectory(dirPath string) ([]GodotScript, []GodotScript, error) {
+	gdScripts := []GodotScript{}
+	csScripts := []GodotScript{}
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ".gd" {
+			gdScripts = append(gdScripts, GodotScript{
+				Path: path,
+				Type: "gd",
+			})
+		} else if filepath.Ext(path) == ".cs" {
+			csScripts = append(csScripts, GodotScript{
+				Path: path,
+				Type: "cs",
+			})
+		}
+		return nil
+	})
+
+	return gdScripts, csScripts, err
+}
+
+func parseScriptPaths(script *GodotScript, project GodotProject) error {
+	// Open the script file for reading
+	file, err := os.Open(script.Path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Create a scanner to read the script line by line
+	scanner := bufio.NewScanner(file)
+	var modifiedLines []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Replace "res://" paths with projectDir
+		line = strings.ReplaceAll(line, "res://", project.Path)
+
+		// Replace "user://" paths with the UserDirectory
+		line = strings.ReplaceAll(line, "user://", project.UserDirectory)
+
+		// Append the modified line to the result
+		modifiedLines = append(modifiedLines, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	// Reopen the script file for writing
+	file, err = os.Create(script.Path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Write the modified lines back to the script file
+	for _, line := range modifiedLines {
+		_, err := file.WriteString(line + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added a package for handling Godot related files and directories
Convert all paths, in Godot scripts, starting with `res://` or `user://` to absolute paths
Auto add configured working project's `modules` directory to working project's `.gitignore` if any modules have been added.